### PR TITLE
Fix undefined glTF variable reference

### DIFF
--- a/src/loader/GOOGLE_tilt_brush_material.d.ts
+++ b/src/loader/GOOGLE_tilt_brush_material.d.ts
@@ -4,6 +4,6 @@ import { GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoa
 export declare class GLTFGoogleTiltBrushMaterialExtension implements GLTFLoaderPlugin {
     constructor(parser: GLTFParser, brushPath: string);
     beforeRoot(): Promise<void> | null;
-    afterRoot(): Promise<void> | null;
+    afterRoot(glTF: Object): Promise<void> | null;
     replaceMaterial(mesh: Object3D, guid: string): void;
 }

--- a/src/loader/GOOGLE_tilt_brush_material.js
+++ b/src/loader/GOOGLE_tilt_brush_material.js
@@ -67,7 +67,7 @@ export class GLTFGoogleTiltBrushMaterialExtension {
         });
     }
 
-    afterRoot() {
+    afterRoot(glTF) {
         const parser = this.parser;
         const json = parser.json;
 


### PR DESCRIPTION
I was getting an error about the `glTF` variable being undefined, and this variable isn't defined anywhere in the project.  It seems like the intent was to take the parsed glTF data that's passed into the `afterRoot()` function, and defining the argument fixes the problem for me.